### PR TITLE
Changing playback speed (tempo) via gesture on main player screen

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/player/gesture/MainPlayerGestureListener.kt
+++ b/app/src/main/java/org/schabi/newpipe/player/gesture/MainPlayerGestureListener.kt
@@ -14,10 +14,12 @@ import org.schabi.newpipe.ktx.AnimationType
 import org.schabi.newpipe.ktx.animate
 import org.schabi.newpipe.player.Player
 import org.schabi.newpipe.player.helper.AudioReactor
+import org.schabi.newpipe.player.helper.PlaybackParameterDialog
 import org.schabi.newpipe.player.helper.PlayerHelper
 import org.schabi.newpipe.player.ui.MainPlayerUi
 import org.schabi.newpipe.util.ThemeHelper.getAndroidDimenPx
 import kotlin.math.abs
+import kotlin.math.roundToInt
 
 /**
  * GestureListener for the player
@@ -102,6 +104,7 @@ class MainPlayerGestureListener(
             binding.volumeRelativeLayout.animate(true, 200, AnimationType.SCALE_AND_ALPHA)
         }
         binding.brightnessRelativeLayout.isVisible = false
+        binding.playbackSpeedRelativeLayout.isVisible = false
     }
 
     private fun onScrollBrightness(distanceY: Float) {
@@ -147,6 +150,42 @@ class MainPlayerGestureListener(
             binding.brightnessRelativeLayout.animate(true, 200, AnimationType.SCALE_AND_ALPHA)
         }
         binding.volumeRelativeLayout.isVisible = false
+        binding.playbackSpeedRelativeLayout.isVisible = false
+    }
+
+    private fun onScrollPlaybackSpeed(distanceY: Float) {
+        val bar: ProgressBar = binding.playbackSpeedProgressBar
+        val maxPlaybackSpeed: Float = PlaybackParameterDialog.getMaxPitchOrSpeed()
+        val minPlaybackSpeed: Float = PlaybackParameterDialog.getMinPitchOrSpeed()
+        val playbackSpeedStep: Float = PlaybackParameterDialog.getCurrentStepSize(player.context) / maxPlaybackSpeed
+
+        // If we just started sliding, change the progress bar to match the current playback speed
+        if (!binding.playbackSpeedRelativeLayout.isVisible) {
+            val playbackSpeedPercent: Float = player.playbackSpeed / maxPlaybackSpeed
+            bar.progress = (playbackSpeedPercent * bar.max).toInt()
+        }
+
+        // Update progress bar
+        bar.incrementProgressBy(distanceY.toInt())
+
+        // Update playback speed
+        val currentProgressPercent: Float = (bar.progress / bar.max.toFloat() / playbackSpeedStep).roundToInt() * playbackSpeedStep
+        val currentPlaybackSpeed: Float = (currentProgressPercent * maxPlaybackSpeed).coerceIn(minPlaybackSpeed, maxPlaybackSpeed)
+
+        player.playbackSpeed = currentPlaybackSpeed
+        if (DEBUG) {
+            Log.d(TAG, "onScroll().playbackSpeedControl, currentPlaybackSpeed = $currentPlaybackSpeed")
+        }
+
+        // Update player center image
+        binding.playbackSpeedTextView.text = PlayerHelper.formatSpeed(currentPlaybackSpeed.toDouble())
+
+        // Make sure the correct layout is visible
+        if (!binding.playbackSpeedRelativeLayout.isVisible) {
+            binding.playbackSpeedRelativeLayout.animate(true, 200, AnimationType.SCALE_AND_ALPHA)
+        }
+        binding.brightnessRelativeLayout.isVisible = false
+        binding.volumeRelativeLayout.isVisible = false
     }
 
     override fun onScrollEnd(event: MotionEvent) {
@@ -156,6 +195,9 @@ class MainPlayerGestureListener(
         }
         if (binding.brightnessRelativeLayout.isVisible) {
             binding.brightnessRelativeLayout.animate(false, 200, AnimationType.SCALE_AND_ALPHA, 200)
+        }
+        if (binding.playbackSpeedRelativeLayout.isVisible) {
+            binding.playbackSpeedRelativeLayout.animate(false, 200, AnimationType.SCALE_AND_ALPHA, 200)
         }
     }
 
@@ -190,23 +232,35 @@ class MainPlayerGestureListener(
 
         isMoving = true
 
-        // -- Brightness and Volume control --
-        if (getDisplayHalfPortion(initialEvent) == DisplayPortion.RIGHT_HALF) {
+        // -- Brightness Volume and Tempo control --
+        if (getDisplayPortion(initialEvent) == DisplayPortion.RIGHT) {
             when (PlayerHelper.getActionForRightGestureSide(player.context)) {
                 player.context.getString(R.string.volume_control_key) ->
                     onScrollVolume(distanceY)
                 player.context.getString(R.string.brightness_control_key) ->
                     onScrollBrightness(distanceY)
+                player.context.getString(R.string.playback_speed_control_key) ->
+                    onScrollPlaybackSpeed(distanceY)
             }
-        } else {
+        } else if (getDisplayPortion(initialEvent) == DisplayPortion.LEFT) {
             when (PlayerHelper.getActionForLeftGestureSide(player.context)) {
                 player.context.getString(R.string.volume_control_key) ->
                     onScrollVolume(distanceY)
                 player.context.getString(R.string.brightness_control_key) ->
                     onScrollBrightness(distanceY)
+                player.context.getString(R.string.playback_speed_control_key) ->
+                    onScrollPlaybackSpeed(distanceY)
+            }
+        } else {
+            when (PlayerHelper.getActionForMiddleGestureSide(player.context)) {
+                player.context.getString(R.string.volume_control_key) ->
+                    onScrollVolume(distanceY)
+                player.context.getString(R.string.brightness_control_key) ->
+                    onScrollBrightness(distanceY)
+                player.context.getString(R.string.playback_speed_control_key) ->
+                    onScrollPlaybackSpeed(distanceY)
             }
         }
-
         return true
     }
 

--- a/app/src/main/java/org/schabi/newpipe/player/helper/PlaybackParameterDialog.java
+++ b/app/src/main/java/org/schabi/newpipe/player/helper/PlaybackParameterDialog.java
@@ -590,6 +590,19 @@ public class PlaybackParameterDialog extends DialogFragment {
         return PlayerHelper.formatPitch(percent);
     }
 
+    public static float getCurrentStepSize(final Context context) {
+        return PreferenceManager.getDefaultSharedPreferences(context)
+                .getFloat(context.getString(R.string.adjustment_step_key), (float) DEFAULT_STEP);
+    }
+
+    public static float getMinPitchOrSpeed() {
+        return (float) MIN_PITCH_OR_SPEED;
+    }
+
+    public static float getMaxPitchOrSpeed() {
+        return (float) MAX_PITCH_OR_SPEED;
+    }
+
     public interface Callback {
         void onPlaybackParameterChanged(float playbackTempo, float playbackPitch,
                                         boolean playbackSkipSilence);

--- a/app/src/main/java/org/schabi/newpipe/player/helper/PlayerHelper.java
+++ b/app/src/main/java/org/schabi/newpipe/player/helper/PlayerHelper.java
@@ -234,6 +234,12 @@ public final class PlayerHelper {
                         context.getString(R.string.default_right_gesture_control_value));
     }
 
+    public static String getActionForMiddleGestureSide(@NonNull final Context context) {
+        return getPreferences(context)
+                .getString(context.getString(R.string.middle_gesture_control_key),
+                        context.getString(R.string.default_middle_gesture_control_value));
+    }
+
     public static String getActionForLeftGestureSide(@NonNull final Context context) {
         return getPreferences(context)
                 .getString(context.getString(R.string.left_gesture_control_key),

--- a/app/src/main/java/org/schabi/newpipe/player/ui/MainPlayerUi.java
+++ b/app/src/main/java/org/schabi/newpipe/player/ui/MainPlayerUi.java
@@ -555,6 +555,7 @@ public final class MainPlayerUi extends VideoPlayerUi implements View.OnLayoutCh
 
             binding.volumeProgressBar.setMax(maxGestureLength);
             binding.brightnessProgressBar.setMax(maxGestureLength);
+            binding.playbackSpeedProgressBar.setMax(maxGestureLength);
 
             setInitialGestureValues();
             binding.itemsListPanel.getLayoutParams().height =

--- a/app/src/main/res/layout/player.xml
+++ b/app/src/main/res/layout/player.xml
@@ -759,6 +759,34 @@
             </RelativeLayout>
 
             <RelativeLayout
+                android:id="@+id/playbackSpeedRelativeLayout"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_centerInParent="true"
+                android:background="@drawable/background_oval_black_transparent"
+                android:visibility="gone"
+                tools:visibility="visible">
+
+                <ProgressBar
+                    android:id="@+id/playbackSpeedProgressBar"
+                    style="?android:progressBarStyleHorizontal"
+                    android:layout_width="128dp"
+                    android:layout_height="128dp"
+                    android:indeterminate="false"
+                    android:progressDrawable="@drawable/progress_circular_white" />
+
+                <TextView
+                    android:id="@+id/playbackSpeedTextView"
+                    android:layout_width="70dp"
+                    android:layout_height="70dp"
+                    android:layout_centerInParent="true"
+                    android:gravity="center"
+                    android:textColor="@color/white"
+                    android:textSize="18sp"
+                    tools:ignore="ContentDescription" />
+            </RelativeLayout>
+
+            <RelativeLayout
                 android:id="@+id/unskipButton"
                 android:visibility="gone"
                 android:clickable="true"

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -729,8 +729,9 @@
     <string name="feed_show_upcoming">Demnächst</string>
     <string name="feed_show_watched">Vollständig angeschaut</string>
     <string name="feed_show_partially_watched">Teilweise angeschaut</string>
-    <string name="left_gesture_control_summary">Geste für die linke Hälfte des Player-Bildschirms auswählen</string>
-    <string name="right_gesture_control_summary">Geste für die rechte Hälfte des Player-Bildschirms auswählen</string>
+    <string name="left_gesture_control_summary">Geste für den linken Teil des Player-Bildschirms auswählen</string>
+    <string name="middle_gesture_control_title">Mittlere Gestenaktion</string>
+    <string name="right_gesture_control_summary">Geste für den rechten Teil des Player-Bildschirms auswählen</string>
     <string name="none">Keine</string>
     <string name="right_gesture_control_title">Rechte Gestenaktion</string>
     <string name="left_gesture_control_title">Linke Gestenaktion</string>
@@ -826,4 +827,5 @@
 \nMöchtest du wirklich fortfahren?</string>
     <string name="import_settings_vulnerable_format">Die Einstellungen in dem zu importierenden Export verwenden ein angreifbares Format, das seit NewPipe 0.27.0 veraltet ist. Stellen Sie sicher, dass der zu importierende Export aus einer vertrauenswürdigen Quelle stammt, und verwenden Sie in Zukunft nur noch Exporte, die aus NewPipe 0.27.0 oder neuer stammen. Die Unterstützung für den Import von Einstellungen in diesem angreifbaren Format wird bald vollständig entfernt werden, und dann werden alte Versionen von NewPipe nicht mehr in der Lage sein, Einstellungen von Exporten aus neuen Versionen zu importieren.</string>
     <string name="audio_track_type_secondary">Sekundär</string>
+    <string name="middle_gesture_control_summary">Geste für den mittleren Teil des Player-Bildschirms auswählen</string>
 </resources>

--- a/app/src/main/res/values/settings_keys.xml
+++ b/app/src/main/res/values/settings_keys.xml
@@ -204,28 +204,48 @@
     <string name="default_left_gesture_control_value">@string/brightness_control_key</string>
     <string name="brightness_control_key">brightness_control</string>
     <string name="volume_control_key">volume_control</string>
+    <string name="playback_speed_control_key">playback_speed_control</string>
     <string name="none_control_key">none_control</string>
     <string-array name="left_gesture_control_description">
         <item>@string/brightness</item>
         <item>@string/volume</item>
+        <item>@string/playback_tempo</item>
         <item>@string/none</item>
     </string-array>
     <string-array name="left_gesture_control_values">
         <item>@string/brightness_control_key</item>
         <item>@string/volume_control_key</item>
+        <item>@string/playback_speed_control_key</item>
+        <item>@string/none_control_key</item>
+    </string-array>
+
+    <string name="middle_gesture_control_key">middle_gesture_control</string>
+    <string name="default_middle_gesture_control_value">@string/playback_speed_control_key</string>
+    <string-array name="middle_gesture_control_description">
+        <item>@string/brightness</item>
+        <item>@string/volume</item>
+        <item>@string/playback_tempo</item>
+        <item>@string/none</item>
+    </string-array>
+    <string-array name="middle_gesture_control_values">
+        <item>@string/brightness_control_key</item>
+        <item>@string/volume_control_key</item>
+        <item>@string/playback_speed_control_key</item>
         <item>@string/none_control_key</item>
     </string-array>
 
     <string name="right_gesture_control_key">right_gesture_control</string>
     <string name="default_right_gesture_control_value">@string/volume_control_key</string>
     <string-array name="right_gesture_control_description">
-        <item>@string/volume</item>
         <item>@string/brightness</item>
+        <item>@string/volume</item>
+        <item>@string/playback_tempo</item>
         <item>@string/none</item>
     </string-array>
     <string-array name="right_gesture_control_values">
-        <item>@string/volume_control_key</item>
         <item>@string/brightness_control_key</item>
+        <item>@string/volume_control_key</item>
+        <item>@string/playback_speed_control_key</item>
         <item>@string/none_control_key</item>
     </string-array>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -106,9 +106,11 @@
     <string name="auto_queue_title">Auto-enqueue next stream</string>
     <string name="auto_queue_summary">Continue ending (non-repeating) playback queue by appending a related stream</string>
     <string name="auto_queue_toggle">Auto-enqueuing</string>
-    <string name="left_gesture_control_summary">Choose gesture for left half of player screen</string>
+    <string name="left_gesture_control_summary">Choose gesture for left part of player screen</string>
     <string name="left_gesture_control_title">Left gesture action</string>
-    <string name="right_gesture_control_summary">Choose gesture for right half of player screen</string>
+    <string name="middle_gesture_control_summary">Choose gesture for middle part of player screen</string>
+    <string name="middle_gesture_control_title">Middle gesture action</string>
+    <string name="right_gesture_control_summary">Choose gesture for right part of player screen</string>
     <string name="right_gesture_control_title">Right gesture action</string>
     <string name="brightness">Brightness</string>
     <string name="volume">Volume</string>

--- a/app/src/main/res/xml/video_audio_settings.xml
+++ b/app/src/main/res/xml/video_audio_settings.xml
@@ -199,6 +199,16 @@
             app:iconSpaceReserved="false" />
 
         <ListPreference
+            android:defaultValue="@string/default_middle_gesture_control_value"
+            android:entries="@array/middle_gesture_control_description"
+            android:entryValues="@array/middle_gesture_control_values"
+            android:key="@string/middle_gesture_control_key"
+            android:summary="@string/middle_gesture_control_summary"
+            android:title="@string/middle_gesture_control_title"
+            app:singleLineTitle="false"
+            app:iconSpaceReserved="false" />
+
+        <ListPreference
             android:defaultValue="@string/default_right_gesture_control_value"
             android:entries="@array/right_gesture_control_description"
             android:entryValues="@array/right_gesture_control_values"


### PR DESCRIPTION
So one does not have to go to the tempo/pitch menu so frequently, I did the following:


- Add third gesture area in the middle third of player screen (code for detecting thirds instead of halves was already present, but unused)
- Add third gesture option: tempo / playback speed
- Add settings item for middle gesture

Tempo is changed in the same increments as set in the tempo/pitch menu.