### PR TITLE
Allow to choose max playback speed in settings to your liking

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/player/gesture/MainPlayerGestureListener.kt
+++ b/app/src/main/java/org/schabi/newpipe/player/gesture/MainPlayerGestureListener.kt
@@ -156,7 +156,7 @@ class MainPlayerGestureListener(
 
     private fun onScrollPlaybackSpeed(distanceY: Float) {
         val bar: ProgressBar = binding.playbackSpeedProgressBar
-        val maxPlaybackSpeed: Float = PlaybackParameterDialog.getMaxPitchOrSpeed()
+        val maxPlaybackSpeed: Float = PlaybackParameterDialog.getMaxPitchOrSpeed(player.context)
         val minPlaybackSpeed: Float = PlaybackParameterDialog.getMinPitchOrSpeed()
         val playbackSpeedStep: Float = PlaybackParameterDialog.getCurrentStepSize(player.context) / maxPlaybackSpeed
 

--- a/app/src/main/java/org/schabi/newpipe/player/helper/PlayerHelper.java
+++ b/app/src/main/java/org/schabi/newpipe/player/helper/PlayerHelper.java
@@ -246,6 +246,7 @@ public final class PlayerHelper {
                         context.getString(R.string.default_left_gesture_control_value));
     }
 
+
     public static boolean isStartMainPlayerFullscreenEnabled(@NonNull final Context context) {
         return getPreferences(context)
                 .getBoolean(context.getString(R.string.start_main_player_fullscreen_key), false);

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -102,6 +102,8 @@
     <string name="popup_remember_size_pos_title">Eigenschaften des Pop-ups merken</string>
     <string name="use_external_video_player_summary">Entfernt Tonspur bei manchen Auflösungen</string>
     <string name="popup_remember_size_pos_summary">Letzte Größe und Position des Pop-ups merken</string>
+    <string name="max_playback_speed_title">Maximale Geschwindigkeit (E)</string>
+    <string name="max_playback_speed_summary">Maximale Wiedergabegeschwindigkeit festlegen</string>
     <string name="show_search_suggestions_title">Suchvorschläge</string>
     <string name="show_search_suggestions_summary">Vorschläge auswählen, die bei der Suche angezeigt werden sollen</string>
     <string name="clear">löschen</string>

--- a/app/src/main/res/values/settings_keys.xml
+++ b/app/src/main/res/values/settings_keys.xml
@@ -200,12 +200,13 @@
         <item>@string/audio_webm_key</item>
     </string-array>
 
-    <string name="left_gesture_control_key">left_gesture_control</string>
-    <string name="default_left_gesture_control_value">@string/brightness_control_key</string>
     <string name="brightness_control_key">brightness_control</string>
     <string name="volume_control_key">volume_control</string>
     <string name="playback_speed_control_key">playback_speed_control</string>
     <string name="none_control_key">none_control</string>
+
+    <string name="left_gesture_control_key">left_gesture_control</string>
+    <string name="default_left_gesture_control_value">@string/brightness_control_key</string>
     <string-array name="left_gesture_control_description">
         <item>@string/brightness</item>
         <item>@string/volume</item>
@@ -247,6 +248,21 @@
         <item>@string/volume_control_key</item>
         <item>@string/playback_speed_control_key</item>
         <item>@string/none_control_key</item>
+    </string-array>
+
+    <string name="max_playback_speed_key">max_playback_speed</string>
+    <string name="default_max_playback_speed_value">3</string>
+    <string-array name="max_playback_speed_description">
+        <item>2x</item>
+        <item>3x</item>
+        <item>5x</item>
+        <item>10x</item>
+    </string-array>
+    <string-array name="max_playback_speed_values">
+        <item>2</item>
+        <item>3</item>
+        <item>5</item>
+        <item>10</item>
     </string-array>
 
     <string name="prefer_original_audio_key">prefer_original_audio</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -115,6 +115,8 @@
     <string name="brightness">Brightness</string>
     <string name="volume">Volume</string>
     <string name="none">None</string>
+    <string name="max_playback_speed_title">Maximum playback speed (E)</string>
+    <string name="max_playback_speed_summary">Choose the maximum playback speed</string>
     <string name="show_search_suggestions_title">Search suggestions</string>
     <string name="show_search_suggestions_summary">Choose the suggestions to show when searching</string>
     <string name="local_search_suggestions">Local search suggestions</string>

--- a/app/src/main/res/xml/video_audio_settings.xml
+++ b/app/src/main/res/xml/video_audio_settings.xml
@@ -218,6 +218,16 @@
             app:singleLineTitle="false"
             app:iconSpaceReserved="false" />
 
+        <ListPreference
+            android:defaultValue="@string/default_max_playback_speed_value"
+            android:entries="@array/max_playback_speed_description"
+            android:entryValues="@array/max_playback_speed_values"
+            android:key="@string/max_playback_speed_key"
+            android:summary="@string/max_playback_speed_summary"
+            android:title="@string/max_playback_speed_title"
+            app:singleLineTitle="false"
+            app:iconSpaceReserved="false" />
+
         <SwitchPreferenceCompat
             android:defaultValue="true"
             android:key="@string/popup_remember_size_pos_key"


### PR DESCRIPTION
While I personally would never want to go above 3x, others ask for up to 10x.

Having 10x does seem to fit everyone at first, it gets quite frustrating, if you use my swipe to change speed feature and can only use 30% of it's range.

With this setting now, everyone can choose their desired upper limit in settings and the speed dialog will obey as well as the swiping action.